### PR TITLE
Upgrade to use multiple loading bars in the same page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 2.9.3
+   - Bump dependencies to support React 16
+
 ## 2.9.2
    - Make terminating animation faster. Ref: #41
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ export default class Header extends React.Component {
 
 Good news is that it doesn't include any positioning. You can attach it to the top of any block or the whole page.
 
+You can even include multiple loading bars on the same page, that will render independently. They need to be provided with
+a scope so that you can adjust them independently.
+
+```jsx
+import LoadingBar from 'react-redux-loading-bar'
+
+export default class Header extends React.Component {
+  render() {
+    return (
+      <header>
+        <LoadingBar />
+      </header>
+      <section>
+        <LoadingBar scope="sectionBar" />
+      </section>
+    )
+  }
+}
+```
+
 Install the reducer to the store:
 
 ```jsx
@@ -93,6 +113,23 @@ const store = createStore(
 )
 ```
 
+## Usage with custom scope (for multiple loading bars)
+
+```jsx
+import { createStore, applyMiddleware } from 'redux'
+import { loadingBarMiddleware } from 'react-redux-loading-bar'
+import rootReducer from './reducers'
+
+const store = createStore(
+  rootReducer,
+  applyMiddleware(
+    loadingBarMiddleware({
+      scope: 'sectionBar',
+    })
+  )
+)
+```
+
 If you're not using `redux-promise-middleware` or any other promise middleware, you can skip installing the `loadingBarMiddleware()` and dispatch `SHOW`/`HIDE` actions manually. The other option is to write your own middleware that will be similar to the [bundled one](https://github.com/mironov/react-redux-loading-bar/blob/master/src/loading_bar_middleware.js).
 
 ## Usage without middleware
@@ -108,6 +145,18 @@ dispatch(hideLoading())
 ```
 
 You need to dispatch `HIDE` as many times as `SHOW` was dispatched to make the bar disappear. In other words, the loading bar is shown until all long running tasks complete.
+
+## Usage without middleware but with scope
+
+You need to provide the scope to the actions:
+
+```jsx
+import { showLoading, hideLoading } from 'react-redux-loading-bar'
+
+dispatch(showLoading('sectionBar'))
+// do long running stuff
+dispatch(hideLoading('sectionBar'))
+```
 
 ## Usage with [`redux-saga`](https://github.com/redux-saga/redux-saga)
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ You can change component import line if your top level redux store object is `im
 ```jsx
 import { ImmutableLoadingBar as LoadingBar } from 'react-redux-loading-bar'
 
-// Use LoadingBar component as usual
+// Mount LoadingBar component as usual
 ```
 
 ## Usage with jQuery Ajax Requests

--- a/build/immutable.js
+++ b/build/immutable.js
@@ -8,9 +8,11 @@ var _reactRedux = require('react-redux');
 
 var _loading_bar = require('./loading_bar');
 
-var mapImmutableStateToProps = function mapImmutableStateToProps(state) {
+var _loading_bar_ducks = require('./loading_bar_ducks');
+
+var mapImmutableStateToProps = function mapImmutableStateToProps(state, ownProps) {
   return {
-    loading: state.get('loadingBar')
+    loading: state.get('loadingBar').get(ownProps.scope || _loading_bar_ducks.DEFAULT_SCOPE)
   };
 };
 

--- a/build/loading_bar.js
+++ b/build/loading_bar.js
@@ -182,10 +182,9 @@ var LoadingBar = exports.LoadingBar = function (_React$Component) {
         transition: 'transform ' + animationTime + 'ms linear',
         width: '100%',
         willChange: 'transform, opacity'
-      };
 
-      // Use default styling if there's no CSS class applied
-      if (!this.props.className) {
+        // Use default styling if there's no CSS class applied
+      };if (!this.props.className) {
         style.height = '3px';
         style.backgroundColor = 'red';
         style.position = 'absolute';

--- a/build/loading_bar.js
+++ b/build/loading_bar.js
@@ -235,7 +235,7 @@ LoadingBar.propTypes = {
 };
 
 LoadingBar.defaultProps = {
-  className: undefined,
+  className: '',
   loading: 0,
   maxProgress: MAX_PROGRESS,
   progressIncrease: PROGRESS_INCREASE,

--- a/build/loading_bar.js
+++ b/build/loading_bar.js
@@ -17,6 +17,8 @@ var _propTypes = require('prop-types');
 
 var _reactRedux = require('react-redux');
 
+var _loading_bar_ducks = require('./loading_bar_ducks');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -225,9 +227,11 @@ LoadingBar.propTypes = {
   maxProgress: _propTypes.number,
   progressIncrease: _propTypes.number,
   showFastActions: _propTypes.bool,
+  updateTime: _propTypes.number,
+  // eslint-disable-next-line react/no-unused-prop-types
+  scope: _propTypes.string,
   // eslint-disable-next-line react/forbid-prop-types
-  style: _propTypes.object,
-  updateTime: _propTypes.number
+  style: _propTypes.object
 };
 
 LoadingBar.defaultProps = {
@@ -237,14 +241,13 @@ LoadingBar.defaultProps = {
   progressIncrease: PROGRESS_INCREASE,
   showFastActions: false,
   style: {},
-  updateTime: UPDATE_TIME
+  updateTime: UPDATE_TIME,
+  scope: _loading_bar_ducks.DEFAULT_SCOPE
 };
 
 var mapStateToProps = function mapStateToProps(state, ownProps) {
-  var scope = ownProps.scope || 'default';
-
   return {
-    loading: state.loadingBar[scope]
+    loading: state.loadingBar[ownProps.scope]
   };
 };
 

--- a/build/loading_bar.js
+++ b/build/loading_bar.js
@@ -247,7 +247,7 @@ LoadingBar.defaultProps = {
 
 var mapStateToProps = function mapStateToProps(state, ownProps) {
   return {
-    loading: state.loadingBar[ownProps.scope]
+    loading: state.loadingBar[ownProps.scope || _loading_bar_ducks.DEFAULT_SCOPE]
   };
 };
 

--- a/build/loading_bar_ducks.js
+++ b/build/loading_bar_ducks.js
@@ -17,8 +17,10 @@ var SHOW = exports.SHOW = 'loading-bar/SHOW';
 var HIDE = exports.HIDE = 'loading-bar/HIDE';
 var RESET = exports.RESET = 'loading-bar/RESET';
 
+var DEFAULT_SCOPE = exports.DEFAULT_SCOPE = 'default';
+
 function showLoading() {
-  var scope = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 'default';
+  var scope = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : DEFAULT_SCOPE;
 
   return {
     type: SHOW,
@@ -29,7 +31,7 @@ function showLoading() {
 }
 
 function hideLoading() {
-  var scope = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 'default';
+  var scope = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : DEFAULT_SCOPE;
 
   return {
     type: HIDE,
@@ -40,7 +42,7 @@ function hideLoading() {
 }
 
 function resetLoading() {
-  var scope = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 'default';
+  var scope = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : DEFAULT_SCOPE;
 
   return {
     type: RESET,
@@ -55,14 +57,14 @@ function loadingBarReducer() {
   var action = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
   var _ref = action.payload || {},
-      scope = _ref.scope;
+      _ref$scope = _ref.scope,
+      scope = _ref$scope === undefined ? DEFAULT_SCOPE : _ref$scope;
 
   switch (action.type) {
     case SHOW:
       return _extends({}, state, _defineProperty({}, scope, (state[scope] || 0) + 1));
-
     case HIDE:
-      return _extends({}, state, _defineProperty({}, scope, (state[scope] || 1) - 1));
+      return _extends({}, state, _defineProperty({}, scope, Math.max(0, (state[scope] || 1) - 1)));
     case RESET:
       return _extends({}, state, _defineProperty({}, scope, 0));
     default:

--- a/build/loading_bar_middleware.js
+++ b/build/loading_bar_middleware.js
@@ -16,6 +16,7 @@ function loadingBarMiddleware() {
   var config = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
   var promiseTypeSuffixes = config.promiseTypeSuffixes || defaultTypeSuffixes;
+  var scope = config.scope || _loading_bar_ducks.DEFAULT_SCOPE;
 
   return function (_ref) {
     var dispatch = _ref.dispatch;
@@ -32,9 +33,9 @@ function loadingBarMiddleware() {
           var isRejected = new RegExp(REJECTED + '$', 'g');
 
           if (action.type.match(isPending)) {
-            dispatch((0, _loading_bar_ducks.showLoading)());
+            dispatch((0, _loading_bar_ducks.showLoading)(scope));
           } else if (action.type.match(isFulfilled) || action.type.match(isRejected)) {
-            dispatch((0, _loading_bar_ducks.hideLoading)());
+            dispatch((0, _loading_bar_ducks.hideLoading)(scope));
           }
         }
 

--- a/build/loading_bar_middleware.js
+++ b/build/loading_bar_middleware.js
@@ -32,10 +32,12 @@ function loadingBarMiddleware() {
           var isFulfilled = new RegExp(FULFILLED + '$', 'g');
           var isRejected = new RegExp(REJECTED + '$', 'g');
 
+          var actionScope = action.scope || scope;
+
           if (action.type.match(isPending)) {
-            dispatch((0, _loading_bar_ducks.showLoading)(scope));
+            dispatch((0, _loading_bar_ducks.showLoading)(actionScope));
           } else if (action.type.match(isFulfilled) || action.type.match(isRejected)) {
-            dispatch((0, _loading_bar_ducks.hideLoading)(scope));
+            dispatch((0, _loading_bar_ducks.hideLoading)(actionScope));
           }
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-loading-bar",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "Simple Loading Bar for Redux and React",
   "main": "build/index.js",
   "typings": "index.d.ts",
@@ -34,8 +34,8 @@
   },
   "homepage": "https://github.com/mironov/react-redux-loading-bar",
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0",
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-redux": "^3.0.0 || ^4.0.0 || ^5.0.0",
     "redux": "^3.0.0"
   },
@@ -48,7 +48,9 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-2": "^6.5.0",
     "coveralls": "^2.11.9",
-    "enzyme": "^2.8.2",
+    "enzyme": "^3.0.0",
+    "enzyme-adapter-react-15": "^1.0.0",
+    "enzyme-adapter-react-16": "^1.0.0",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",
@@ -61,10 +63,10 @@
     "lolex": "^1.4.0",
     "mocha": "^3.2.0",
     "pkgfiles": "^2.3.0",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-redux": "^5.0.4",
-    "react-test-renderer": "^15.5.4",
+    "react-test-renderer": "^16.0.0",
     "redux": "^3.5.2"
   },
   "dependencies": {

--- a/spec/loading_bar.js
+++ b/spec/loading_bar.js
@@ -74,6 +74,29 @@ describe('LoadingBar', () => {
       expect(resultStyle.height).toEqual(undefined)
       expect(resultStyle.position).toEqual(undefined)
     })
+
+    it('renders multiple instances in the same dom', () => {
+      const wrapper = mount(
+        <section>
+          <LoadingBar />
+          <LoadingBar scope="someScope" className="custom" />
+        </section> // eslint-disable-line comma-dangle
+      )
+
+      const sectionWrapper = wrapper.find('section').at(0)
+
+      const loadingBarDefault = sectionWrapper.childAt(0).find('div').at(1)
+      expect(loadingBarDefault.props().className).toEqual('')
+      expect(loadingBarDefault.props().style.opacity).toEqual('0')
+      expect(loadingBarDefault.props().style.backgroundColor).toEqual('red')
+      expect(loadingBarDefault.props().style.height).toEqual('3px')
+
+      const loadingBarCustom = sectionWrapper.childAt(1).find('div').at(1)
+      expect(loadingBarCustom.props().className).toEqual('custom')
+      expect(loadingBarCustom.props().style.backgroundColor).toEqual(undefined)
+      expect(loadingBarCustom.props().style.height).toEqual(undefined)
+      expect(loadingBarCustom.props().style.position).toEqual(undefined)
+    })
   })
 
   describe('#componentWillReceiveProps', () => {

--- a/spec/loading_bar.js
+++ b/spec/loading_bar.js
@@ -1,6 +1,7 @@
 /* eslint import/no-extraneous-dependencies: 0 */
 import React from 'react'
-import { shallow, mount } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+import Enzyme, { shallow, mount } from 'enzyme'
 import expect, { spyOn } from 'expect'
 import expectJSX from 'expect-jsx'
 import lolex from 'lolex'
@@ -14,6 +15,7 @@ import {
   ANIMATION_TIME,
 } from '../src/loading_bar'
 
+Enzyme.configure({ adapter: new Adapter() })
 expect.extend(expectJSX)
 
 // Setup jsdom to let enzyme's mount work
@@ -26,19 +28,19 @@ describe('LoadingBar', () => {
     it('renders without problems', () => {
       const wrapper = shallow(<LoadingBar />)
 
-      expect(wrapper.node.type).toEqual('div')
+      expect(wrapper.getElement().type).toEqual('div')
     })
 
     it('renders an empty div before mount', () => {
       const wrapper = shallow(<LoadingBar />)
 
-      expect(wrapper.children().node).toEqual(undefined)
+      wrapper.equals(<div />)
     })
 
     it('renders by default hidden 3px height red element', () => {
       const wrapper = mount(<LoadingBar />)
 
-      const resultStyle = wrapper.childAt(0).props().style
+      const resultStyle = wrapper.find('div').at(1).props().style
       expect(resultStyle.opacity).toEqual('0')
       expect(resultStyle.backgroundColor).toEqual('red')
       expect(resultStyle.height).toEqual('3px')
@@ -48,7 +50,7 @@ describe('LoadingBar', () => {
       const style = { backgroundColor: 'blue', height: '5px' }
       const wrapper = mount(<LoadingBar style={style} />)
 
-      const resultStyle = wrapper.childAt(0).props().style
+      const resultStyle = wrapper.find('div').at(1).props().style
       expect(resultStyle.backgroundColor).toEqual('blue')
       expect(resultStyle.height).toEqual('5px')
     })
@@ -57,7 +59,7 @@ describe('LoadingBar', () => {
       const wrapper = mount(<LoadingBar loading={1} />)
       wrapper.setState({ percent: 10 })
 
-      const resultStyle = wrapper.childAt(0).props().style
+      const resultStyle = wrapper.find('div').at(1).props().style
       expect(resultStyle.opacity).toEqual('1')
       expect(resultStyle.backgroundColor).toEqual('red')
       expect(resultStyle.height).toEqual('3px')
@@ -67,7 +69,7 @@ describe('LoadingBar', () => {
     it('does not apply styling if CSS class is specified', () => {
       const wrapper = mount(<LoadingBar className="custom" />)
 
-      const resultStyle = wrapper.childAt(0).props().style
+      const resultStyle = wrapper.find('div').at(1).props().style
       expect(resultStyle.backgroundColor).toEqual(undefined)
       expect(resultStyle.height).toEqual(undefined)
       expect(resultStyle.position).toEqual(undefined)

--- a/spec/loading_bar_ducks.js
+++ b/spec/loading_bar_ducks.js
@@ -6,6 +6,7 @@ import {
   SHOW,
   HIDE,
   RESET,
+  DEFAULT_SCOPE,
   showLoading,
   hideLoading,
   resetLoading,
@@ -13,64 +14,81 @@ import {
 
 describe('loadingBarReducer', () => {
   it('returns the initial state', () => {
-    expect(loadingBarReducer(undefined, {})).toEqual(0)
+    expect(loadingBarReducer(undefined, {})).toEqual({})
   })
 
   it('handles SHOW', () => {
     expect(
       loadingBarReducer(undefined, { type: SHOW }),
-    ).toEqual(1)
+    ).toEqual({ [DEFAULT_SCOPE]: 1 })
 
     expect(
-      loadingBarReducer(0, { type: SHOW }),
-    ).toEqual(1)
+      loadingBarReducer({ [DEFAULT_SCOPE]: 0 }, { type: SHOW }),
+    ).toEqual({ [DEFAULT_SCOPE]: 1 })
 
     expect(
-      loadingBarReducer(1, { type: SHOW }),
-    ).toEqual(2)
+      loadingBarReducer({ [DEFAULT_SCOPE]: 1 }, { type: SHOW }),
+    ).toEqual({ [DEFAULT_SCOPE]: 2 })
   })
 
   it('handles HIDE', () => {
     expect(
-      loadingBarReducer(1, { type: HIDE }),
-    ).toEqual(0)
+      loadingBarReducer({ [DEFAULT_SCOPE]: 1 }, { type: HIDE }),
+    ).toEqual({ [DEFAULT_SCOPE]: 0 })
 
     expect(
       loadingBarReducer(undefined, { type: HIDE }),
-    ).toEqual(0)
-
+    ).toEqual({ [DEFAULT_SCOPE]: 0 })
 
     expect(
-      loadingBarReducer(0, { type: HIDE }),
-    ).toEqual(0)
+      loadingBarReducer({ [DEFAULT_SCOPE]: 0 }, { type: HIDE }),
+    ).toEqual({ [DEFAULT_SCOPE]: 0 })
   })
 
   it('handles RESET', () => {
     expect(
-      loadingBarReducer(1, { type: RESET }),
-    ).toEqual(0)
+      loadingBarReducer({ [DEFAULT_SCOPE]: 1 }, { type: RESET }),
+    ).toEqual({ [DEFAULT_SCOPE]: 0 })
 
     expect(
       loadingBarReducer(undefined, { type: RESET }),
-    ).toEqual(0)
+    ).toEqual({ [DEFAULT_SCOPE]: 0 })
 
 
     expect(
-      loadingBarReducer(10, { type: RESET }),
-    ).toEqual(0)
+      loadingBarReducer({ [DEFAULT_SCOPE]: 10 }, { type: RESET }),
+    ).toEqual({ [DEFAULT_SCOPE]: 0 })
   })
 })
 
 describe('actions', () => {
   it('creates an action to show loading bar', () => {
-    expect(showLoading()).toEqual({ type: SHOW })
+    expect(showLoading())
+    .toEqual({ type: SHOW, payload: { scope: DEFAULT_SCOPE } })
+  })
+
+  it('creates an action to show a custom loading bar', () => {
+    expect(showLoading('someScope'))
+    .toEqual({ type: SHOW, payload: { scope: 'someScope' } })
   })
 
   it('creates an action to hide loading bar', () => {
-    expect(hideLoading()).toEqual({ type: HIDE })
+    expect(hideLoading())
+    .toEqual({ type: HIDE, payload: { scope: DEFAULT_SCOPE } })
+  })
+
+  it('creates an action to hide a custom loading bar', () => {
+    expect(hideLoading('someScope'))
+    .toEqual({ type: HIDE, payload: { scope: 'someScope' } })
   })
 
   it('creates an action to reset loading bar', () => {
-    expect(resetLoading()).toEqual({ type: RESET })
+    expect(resetLoading())
+    .toEqual({ type: RESET, payload: { scope: DEFAULT_SCOPE } })
+  })
+
+  it('creates an action to reset a custom loading bar', () => {
+    expect(resetLoading('someScope'))
+    .toEqual({ type: RESET, payload: { scope: 'someScope' } })
   })
 })

--- a/spec/loading_bar_middleware.js
+++ b/spec/loading_bar_middleware.js
@@ -206,4 +206,74 @@ describe('loadingBarMiddleware', () => {
       expect(expectedActions.length).toEqual(0)
     })
   })
+
+  describe('with custom scope', () => {
+    const CUSTOM_SCOPE = 'someScope'
+    const mockStoreWithCustomScope = mockDispatch =>
+      createMockStore(
+        [
+          loadingBarMiddleware({
+            scope: CUSTOM_SCOPE,
+          }),
+        ],
+        mockDispatch,
+      )
+
+    describe('with an action containing "_PENDING" in type', () => {
+      it('dispatches SHOW action', () => {
+        const originalAction = { type: 'something/FETCH_PENDING' }
+        const expectedActions = [
+          showLoading(CUSTOM_SCOPE),
+          originalAction,
+        ]
+
+        const mockDispatch = (action) => {
+          const expectedAction = expectedActions.shift()
+          expect(action).toEqual(expectedAction)
+          return action
+        }
+
+        mockStoreWithCustomScope(mockDispatch).dispatch(originalAction)
+        expect(expectedActions.length).toEqual(0)
+      })
+    })
+
+    describe('with an action containing "_FULFILLED" in type', () => {
+      it('dispatches HIDE action', () => {
+        const originalAction = { type: 'something/FETCH_FULFILLED' }
+        const expectedActions = [
+          hideLoading(CUSTOM_SCOPE),
+          originalAction,
+        ]
+
+        const mockDispatch = (action) => {
+          const expectedAction = expectedActions.shift()
+          expect(action).toEqual(expectedAction)
+          return action
+        }
+
+        mockStoreWithCustomScope(mockDispatch).dispatch(originalAction)
+        expect(expectedActions.length).toEqual(0)
+      })
+    })
+
+    describe('with an action containing "_REJECTED" in type', () => {
+      it('dispatches HIDE action', () => {
+        const originalAction = { type: 'something/FETCH_REJECTED' }
+        const expectedActions = [
+          hideLoading(CUSTOM_SCOPE),
+          originalAction,
+        ]
+
+        const mockDispatch = (action) => {
+          const expectedAction = expectedActions.shift()
+          expect(action).toEqual(expectedAction)
+          return action
+        }
+
+        mockStoreWithCustomScope(mockDispatch).dispatch(originalAction)
+        expect(expectedActions.length).toEqual(0)
+      })
+    })
+  })
 })

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -1,8 +1,10 @@
 import { connect } from 'react-redux'
 import { LoadingBar } from './loading_bar'
 
-const mapImmutableStateToProps = state => ({
-  loading: state.get('loadingBar'),
+import { DEFAULT_SCOPE } from './loading_bar_ducks'
+
+const mapImmutableStateToProps = (state, ownProps) => ({
+  loading: state.get('loadingBar').get(ownProps.scope || DEFAULT_SCOPE),
 })
 
 export default connect(mapImmutableStateToProps)(LoadingBar)

--- a/src/loading_bar.js
+++ b/src/loading_bar.js
@@ -200,7 +200,7 @@ LoadingBar.propTypes = {
 }
 
 LoadingBar.defaultProps = {
-  className: undefined,
+  className: '',
   loading: 0,
   maxProgress: MAX_PROGRESS,
   progressIncrease: PROGRESS_INCREASE,

--- a/src/loading_bar.js
+++ b/src/loading_bar.js
@@ -211,7 +211,7 @@ LoadingBar.defaultProps = {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  loading: state.loadingBar[ownProps.scope],
+  loading: state.loadingBar[ownProps.scope || DEFAULT_SCOPE],
 })
 
 export default connect(mapStateToProps)(LoadingBar)

--- a/src/loading_bar.js
+++ b/src/loading_bar.js
@@ -7,6 +7,8 @@ import {
 } from 'prop-types'
 import { connect } from 'react-redux'
 
+import { DEFAULT_SCOPE } from './loading_bar_ducks'
+
 export const UPDATE_TIME = 200
 export const MAX_PROGRESS = 99
 export const PROGRESS_INCREASE = 10
@@ -190,9 +192,11 @@ LoadingBar.propTypes = {
   maxProgress: number,
   progressIncrease: number,
   showFastActions: bool,
+  updateTime: number,
+  // eslint-disable-next-line react/no-unused-prop-types
+  scope: string,
   // eslint-disable-next-line react/forbid-prop-types
   style: object,
-  updateTime: number,
 }
 
 LoadingBar.defaultProps = {
@@ -203,14 +207,11 @@ LoadingBar.defaultProps = {
   showFastActions: false,
   style: {},
   updateTime: UPDATE_TIME,
+  scope: DEFAULT_SCOPE,
 }
 
-const mapStateToProps = (state, ownProps) => {
-  const scope = ownProps.scope || 'default'
-
-  return {
-    loading: state.loadingBar[scope],
-  }
-}
+const mapStateToProps = (state, ownProps) => ({
+  loading: state.loadingBar[ownProps.scope],
+})
 
 export default connect(mapStateToProps)(LoadingBar)

--- a/src/loading_bar_ducks.js
+++ b/src/loading_bar_ducks.js
@@ -2,7 +2,9 @@ export const SHOW = 'loading-bar/SHOW'
 export const HIDE = 'loading-bar/HIDE'
 export const RESET = 'loading-bar/RESET'
 
-export function showLoading(scope = 'default') {
+export const DEFAULT_SCOPE = 'default'
+
+export function showLoading(scope = DEFAULT_SCOPE) {
   return {
     type: SHOW,
     payload: {
@@ -11,7 +13,7 @@ export function showLoading(scope = 'default') {
   }
 }
 
-export function hideLoading(scope = 'default') {
+export function hideLoading(scope = DEFAULT_SCOPE) {
   return {
     type: HIDE,
     payload: {
@@ -20,7 +22,7 @@ export function hideLoading(scope = 'default') {
   }
 }
 
-export function resetLoading(scope = 'default') {
+export function resetLoading(scope = DEFAULT_SCOPE) {
   return {
     type: RESET,
     payload: {
@@ -30,7 +32,7 @@ export function resetLoading(scope = 'default') {
 }
 
 export function loadingBarReducer(state = {}, action = {}) {
-  const { scope } = (action.payload || {});
+  const { scope = DEFAULT_SCOPE } = (action.payload || {})
 
   switch (action.type) {
     case SHOW:
@@ -38,11 +40,10 @@ export function loadingBarReducer(state = {}, action = {}) {
         ...state,
         [scope]: (state[scope] || 0) + 1,
       }
-
     case HIDE:
       return {
         ...state,
-        [scope]: (state[scope] || 1) - 1,
+        [scope]: Math.max(0, (state[scope] || 1) - 1),
       }
     case RESET:
       return {

--- a/src/loading_bar_middleware.js
+++ b/src/loading_bar_middleware.js
@@ -14,11 +14,13 @@ export default function loadingBarMiddleware(config = {}) {
       const isFulfilled = new RegExp(`${FULFILLED}$`, 'g')
       const isRejected = new RegExp(`${REJECTED}$`, 'g')
 
+      const actionScope = action.scope || scope
+
       if (action.type.match(isPending)) {
-        dispatch(showLoading(scope))
+        dispatch(showLoading(actionScope))
       } else if (action.type.match(isFulfilled) ||
                  action.type.match(isRejected)) {
-        dispatch(hideLoading(scope))
+        dispatch(hideLoading(actionScope))
       }
     }
 

--- a/src/loading_bar_middleware.js
+++ b/src/loading_bar_middleware.js
@@ -1,9 +1,10 @@
-import { showLoading, hideLoading } from './loading_bar_ducks'
+import { DEFAULT_SCOPE, showLoading, hideLoading } from './loading_bar_ducks'
 
 const defaultTypeSuffixes = ['PENDING', 'FULFILLED', 'REJECTED']
 
 export default function loadingBarMiddleware(config = {}) {
   const promiseTypeSuffixes = config.promiseTypeSuffixes || defaultTypeSuffixes
+  const scope = config.scope || DEFAULT_SCOPE
 
   return ({ dispatch }) => next => (action) => {
     if (action.type) {
@@ -14,10 +15,10 @@ export default function loadingBarMiddleware(config = {}) {
       const isRejected = new RegExp(`${REJECTED}$`, 'g')
 
       if (action.type.match(isPending)) {
-        dispatch(showLoading())
+        dispatch(showLoading(scope))
       } else if (action.type.match(isFulfilled) ||
                  action.type.match(isRejected)) {
-        dispatch(hideLoading())
+        dispatch(hideLoading(scope))
       }
     }
 


### PR DESCRIPTION
Updated the README.md file
Updated the middleware
Updated the implementation of the reducers
Updated the loadingbar itself.
Updated the immutable implementation.
Updated the tests and added more tests for that specific case.

All of the above now use the internal `scope` variable to define which loading bar to update.